### PR TITLE
Fix Security Object table markdown

### DIFF
--- a/REST Builder.md
+++ b/REST Builder.md
@@ -71,7 +71,7 @@ The Application object parameters are:
 #### Security Object
 The Security object parameters are:
 
-|| Field Name | Type  | Description | Required |
+| Field Name | Type  | Description | Required |
 | ---------- | :---: | ----------- | :------: |
 | basicAuth | string | Basic authentication | false |
 | guestAllowed | string | Allow guest access | false |


### PR DESCRIPTION
The Security Object table display is broken because of an extra "|" character in the markdown. This pull request fix it.